### PR TITLE
Add recipe search

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/FatSecretSwift.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/FatSecretSwift.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FatSecretSwift"
+               BuildableName = "FatSecretSwift"
+               BlueprintName = "FatSecretSwift"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FatSecretSwiftTests"
+               BuildableName = "FatSecretSwiftTests"
+               BlueprintName = "FatSecretSwiftTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FatSecretSwift"
+            BuildableName = "FatSecretSwift"
+            BlueprintName = "FatSecretSwift"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/FatSecretSwift/Certificate.swift
+++ b/Sources/FatSecretSwift/Certificate.swift
@@ -55,8 +55,8 @@ extension Certificate {
     }
 }
 
-class CertificatePinningURLSessionDelegate: NSObject, URLSessionDelegate {
-    func urlSession(_ session: URLSession,
+public class CertificatePinningURLSessionDelegate: NSObject, URLSessionDelegate {
+    public func urlSession(_ session: URLSession,
                     didReceive challenge: URLAuthenticationChallenge,
                     completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Swift.Void) {
         guard let serverTrust = challenge.protectionSpace.serverTrust,

--- a/Sources/FatSecretSwift/Certificate.swift
+++ b/Sources/FatSecretSwift/Certificate.swift
@@ -10,6 +10,17 @@
 import Foundation
 import Security
 
+// For expired + upcoming certificate
+enum kCertificate: String {
+    case renewed    = "CertificateRenewed"      // CertificateRenewed
+    case current    = "fatsecret.com"           // Certificate
+    case domain     = "platform.fatsecret.com"  // domain to validate
+    
+    var name: String {
+        self.rawValue
+    }
+}
+
 
 struct Certificate {
     let certificate: SecCertificate
@@ -17,10 +28,10 @@ struct Certificate {
 }
 
 extension Certificate {
-    static func localCertificates(with names: [String] = ["CertificateRenewed", "Certificate"],
+    static func localCertificates(with names: [String] = [kCertificate.renewed.name, kCertificate.current.name],
                                   from bundle: Bundle = .main) -> [Certificate] {
         return names.lazy.map({
-            guard let file = bundle.url(forResource: $0, withExtension: "cer"),
+            guard let file = bundle.url(forResource: $0, withExtension: "der"),
                 let data = try? Data(contentsOf: file),
                 let cert = SecCertificateCreateWithData(nil, data as CFData) else {
                     return nil
@@ -55,7 +66,7 @@ class CertificatePinningURLSessionDelegate: NSObject, URLSessionDelegate {
         }
 
         //Set policy to validate domain
-        let policy = SecPolicyCreateSSL(true, "platform.fatsecret.com" as CFString)
+        let policy = SecPolicyCreateSSL(true, kCertificate.domain.name as CFString)
         let policies = NSArray(object: policy)
         SecTrustSetPolicies(serverTrust, policies)
 

--- a/Sources/FatSecretSwift/Certificate.swift
+++ b/Sources/FatSecretSwift/Certificate.swift
@@ -12,8 +12,8 @@ import Security
 
 // For expired + upcoming certificate
 enum kCertificate: String {
-    case renewed    = "CertificateRenewed"      // CertificateRenewed
-    case current    = "fatsecret.com"           // Certificate
+    case renewed    = "CertificateRenewed"      // CertificateRenewed; use placeholder for now
+    case current    = "fatsecretCurrent"        // Certificate
     case domain     = "platform.fatsecret.com"  // domain to validate
     
     var name: String {

--- a/Sources/FatSecretSwift/Certificate.swift
+++ b/Sources/FatSecretSwift/Certificate.swift
@@ -1,0 +1,151 @@
+//
+//  Certificate.swift
+//  
+//
+//  Created by Super Grover on 2023-10-15.
+//
+// Adapted from: https://gist.github.com/daniel-rueda/132c1a556dad7cf6b734b59ed47a1f75
+// Based on https://code.tutsplus.com/articles/securing-communications-on-ios--cms-28529
+
+import Foundation
+import Security
+
+
+struct Certificate {
+    let certificate: SecCertificate
+    let data: Data
+}
+
+extension Certificate {
+    static func localCertificates(with names: [String] = ["CertificateRenewed", "Certificate"],
+                                  from bundle: Bundle = .main) -> [Certificate] {
+        return names.lazy.map({
+            guard let file = bundle.url(forResource: $0, withExtension: "cer"),
+                let data = try? Data(contentsOf: file),
+                let cert = SecCertificateCreateWithData(nil, data as CFData) else {
+                    return nil
+            }
+            return Certificate(certificate: cert, data: data)
+        }).compactMap({$0})
+    }
+
+    func validate(against certData: Data, using secTrust: SecTrust) -> Bool {
+        let certArray = [certificate] as CFArray
+        SecTrustSetAnchorCertificates(secTrust, certArray)
+
+        //validates a certificate by verifying its signature plus the signatures of
+        // the certificates in its certificate chain, up to the anchor certificate
+        var result = SecTrustResultType.invalid
+        SecTrustEvaluate(secTrust, &result)
+        let isValid = (result == .unspecified || result == .proceed)
+
+        //Validate host certificate against pinned certificate.
+        return isValid && certData == self.data
+    }
+}
+
+class CertificatePinningURLSessionDelegate: NSObject, URLSessionDelegate {
+    func urlSession(_ session: URLSession,
+                    didReceive challenge: URLAuthenticationChallenge,
+                    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Swift.Void) {
+        guard let serverTrust = challenge.protectionSpace.serverTrust,
+            challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust else {
+                completionHandler(.cancelAuthenticationChallenge, nil)
+                return
+        }
+
+        //Set policy to validate domain
+        let policy = SecPolicyCreateSSL(true, "platform.fatsecret.com" as CFString)
+        let policies = NSArray(object: policy)
+        SecTrustSetPolicies(serverTrust, policies)
+
+        let certificateCount = SecTrustGetCertificateCount(serverTrust)
+        guard certificateCount > 0,
+            let certificate = SecTrustGetCertificateAtIndex(serverTrust, 0) else {
+                completionHandler(.cancelAuthenticationChallenge, nil)
+                return
+        }
+
+        let serverCertificateData = SecCertificateCopyData(certificate) as Data
+        let certificates = Certificate.localCertificates()
+        for localCert in certificates {
+            if localCert.validate(against: serverCertificateData, using: serverTrust) {
+                completionHandler(.useCredential, URLCredential(trust: serverTrust))
+                return // exit as soon as we found a match
+            }
+        }
+
+        // No valid cert available
+        completionHandler(.cancelAuthenticationChallenge, nil)
+    }
+}
+
+
+// --------------------------------------------------------------------------------------------------------
+// Above, nicely cleans up the below
+// from: https://code.tutsplus.com/articles/securing-communications-on-ios--cms-28529:
+class URLSessionPinningDelegate: NSObject, URLSessionDelegate
+{
+    func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Swift.Void)
+    {
+        var success: Bool = false
+        if let serverTrust = challenge.protectionSpace.serverTrust
+        {
+            if (challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust)
+            {
+                //Set policy to validate domain
+                let policy: SecPolicy = SecPolicyCreateSSL(true, "yourdomain.com" as CFString)
+                let policies = NSArray.init(object: policy)
+                SecTrustSetPolicies(serverTrust, policies)
+                
+                let certificateCount: CFIndex = SecTrustGetCertificateCount(serverTrust)
+                if certificateCount > 0
+                {
+                    if let certificate = SecTrustGetCertificateAtIndex(serverTrust, 0)
+                    {
+                        let serverCertificateData = SecCertificateCopyData(certificate) as NSData
+                        
+                        //for loop over array which may contain expired + upcoming certificate
+                        let certFilenames: [String] = ["CertificateRenewed", "Certificate"]
+                        for filenameString: String in certFilenames
+                        {
+                            let filePath = Bundle.main.path(forResource: filenameString, ofType: "cer")
+                            if let file = filePath
+                            {
+                                if let localCertData = NSData(contentsOfFile: file)
+                                {
+                                    //Set anchor cert to your own server
+                                    if let localCert: SecCertificate = SecCertificateCreateWithData(nil, localCertData)
+                                    {
+                                        let certArray = [localCert] as CFArray
+                                        SecTrustSetAnchorCertificates(serverTrust, certArray)
+                                    }
+                                    
+                                    //validates a certificate by verifying its signature plus the signatures of the certificates in its certificate chain, up to the anchor certificate
+                                    var result = SecTrustResultType.invalid
+                                    SecTrustEvaluate(serverTrust, &result);
+                                    let isValid: Bool = (result == SecTrustResultType.unspecified || result == SecTrustResultType.proceed)
+                                    if (isValid)
+                                    {
+                                        //Validate host certificate against pinned certificate.
+                                        if serverCertificateData.isEqual(to: localCertData as Data)
+                                        {
+                                            success = true
+                                            completionHandler(.useCredential, URLCredential(trust:serverTrust))
+                                            break //found a successful certificate, don't need to continue looping
+                                        } //end if serverCertificateData.isEqual(to: localCertData as Data)
+                                    } //end if (isValid)
+                                } //end if let localCertData = NSData(contentsOfFile: file)
+                            } //end if let file = filePath
+                        } //end for filenameString: String in certFilenames
+                    } //end if let certificate = SecTrustGetCertificateAtIndex(serverTrust, 0)
+                } //end if certificateCount > 0
+            } //end if (challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust)
+        } //end if let serverTrust = challenge.protectionSpace.serverTrust
+        
+        if (success == false)
+        {
+            completionHandler(.cancelAuthenticationChallenge, nil)
+        }
+    }
+}

--- a/Sources/FatSecretSwift/Extensions/String+Utils.swift
+++ b/Sources/FatSecretSwift/Extensions/String+Utils.swift
@@ -7,10 +7,10 @@ internal extension String {
      Also refered to as percent encoding.
      */
     func getPercentEncodingCharacterSet() -> String {
-        let digits = "0123456789"
-        let lowercase = "abcdefghijklmnopqrstuvwxyz"
-        let uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        let unreserved = "-._~"
+        let digits      = "0123456789"
+        let lowercase   = "abcdefghijklmnopqrstuvwxyz"
+        let uppercase   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        let unreserved  = "-._~"
 
         return digits + lowercase + uppercase + unreserved
     }

--- a/Sources/FatSecretSwift/Extensions/String+Utils.swift
+++ b/Sources/FatSecretSwift/Extensions/String+Utils.swift
@@ -31,7 +31,7 @@ internal extension String {
         var array = [UInt8]()
         array += params.utf8
 
-        let sign = try! HMAC(key: key, variant: .sha1).authenticate(array).toBase64()!
+        let sign = try! HMAC(key: key, variant: .sha1).authenticate(array).toBase64()
 
         return sign
     }

--- a/Sources/FatSecretSwift/FatSecretClient.swift
+++ b/Sources/FatSecretSwift/FatSecretClient.swift
@@ -91,7 +91,7 @@ open class FatSecretClient {
     /** Recipe Search
      - Description: Search for a recipe by name
      */
-    public func searchRecipe(name: String, completion: @escaping (_ recipes: FSPRecipes) -> Void) {
+    public func searchRecipe(name: String, completion: @escaping (_ recipes: FSPRecipes?) -> Void) {
         print("\nFatSecretClient/searchRecipe....")
         FatSecretParams.fatSecret = ["format":"json", "method":"recipes.search.v2", "must_have_images":"true", "search_expression":name] as Dictionary
 

--- a/Sources/FatSecretSwift/FatSecretClient.swift
+++ b/Sources/FatSecretSwift/FatSecretClient.swift
@@ -177,11 +177,13 @@ extension FatSecretClient {
     }
 
     
-    func fatSecretRecipeSearchRequest(with components: URLComponents, completed: @escaping (Result<FSPRecipes, FBError>) -> Void) {
+    func fatSecretRecipeSearchRequest(with components: URLComponents, certPinningDelegate: CertificatePinningURLSessionDelegate? = nil, completed: @escaping (Result<FSPRecipes, FBError>) -> Void) {
         var request = URLRequest(url: URL(string: String(describing: components).replacingOccurrences(of: "+", with: "%2B"))!)
         request.httpMethod = FatSecretParams.httpType
 
-        let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
+        let session = URLSession(configuration: URLSessionConfiguration.ephemeral, delegate: certPinningDelegate, delegateQueue: nil)
+        
+        let task = session.dataTask(with: request) { (data, response, error) in
             if let _ = error {
                 completed(.failure(.unableToComplete))
                 return
@@ -212,11 +214,13 @@ extension FatSecretClient {
     }
     
     
-    func fatSecretRecipeIDRequest(with components: URLComponents, completed: @escaping (Result<FSPSingleRecipe, FBError>) -> Void) {
+    func fatSecretRecipeIDRequest(with components: URLComponents, certPinningDelegate: CertificatePinningURLSessionDelegate? = nil, completed: @escaping (Result<FSPSingleRecipe, FBError>) -> Void) {
         var request = URLRequest(url: URL(string: String(describing: components).replacingOccurrences(of: "+", with: "%2B"))!)
         request.httpMethod = FatSecretParams.httpType
 
-        let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
+        let session = URLSession(configuration: URLSessionConfiguration.ephemeral, delegate: certPinningDelegate, delegateQueue: nil)
+        
+        let task = session.dataTask(with: request) { (data, response, error) in
             if let _ = error {
                 completed(.failure(.unableToComplete))
                 return

--- a/Sources/FatSecretSwift/FatSecretClient.swift
+++ b/Sources/FatSecretSwift/FatSecretClient.swift
@@ -106,7 +106,7 @@ open class FatSecretClient {
         fatSecretRecipeSearchRequest(with: components) { result in
             switch result {
             case .success(let recipes):
-                print("Successfully found recipes over internet.")
+//                print("Successfully found recipes over internet.")
                 completion(.success(recipes))
 
             case .failure(let error):
@@ -120,14 +120,13 @@ open class FatSecretClient {
      - Description: Get a recipe item by id
      */
     public func getRecipe(id: String, completion: @escaping (Result<FSPSingleRecipe, FBError>) -> Void) {
-        print("\nFatSecretClient/searching for Recipe ID....")
         FatSecretParams.fatSecret = ["format":"json", "method":"recipe.get", "recipe_id":id] as Dictionary
 
         let components = generateSignature()
         fatSecretRecipeIDRequest(with: components) { result in
             switch result {
             case .success(let recipe):
-                print("Successfully found recipe id over internet.")
+//                print("Successfully found recipe id over internet.")
                 completion(.success(recipe))
 
             case .failure(let error):

--- a/Sources/FatSecretSwift/FatSecretClient.swift
+++ b/Sources/FatSecretSwift/FatSecretClient.swift
@@ -25,6 +25,12 @@ private enum HTTPError: LocalizedError {
     }
 }
 
+
+private enum maxSearchResults {
+    static let foods    = 50
+    static let recipes  = 50
+}
+
 /** HTTP Method: POST
  - URL: http://platform.fatsecret.com/rest/server.api
  */
@@ -91,9 +97,10 @@ open class FatSecretClient {
     /** Recipe Search
      - Description: Search for a recipe by name
      */
-    public func searchRecipe(name: String, completion: @escaping (Result<FSPRecipes, FBError>) -> Void) {
+    public func searchRecipe(name: String, maxResults: Int = 20, completion: @escaping (Result<FSPRecipes, FBError>) -> Void) {
         print("\nFatSecretClient/searchRecipe....")
-        FatSecretParams.fatSecret = ["format":"json", "method":"recipes.search.v2", "must_have_images":"true", "search_expression":name] as Dictionary
+        let max = (0...50).contains(maxResults) ? maxResults : 20   // maxResults cannot be more than 50. Default value is 20.
+        FatSecretParams.fatSecret = ["format":"json", "method":"recipes.search.v2", "must_have_images":"true", "search_expression":name, "max_results": String(max)] as Dictionary
 
         let components = generateSignature()
         fatSecretRecipeSearchRequest(with: components) { result in

--- a/Sources/FatSecretSwift/FatSecretClient.swift
+++ b/Sources/FatSecretSwift/FatSecretClient.swift
@@ -104,7 +104,7 @@ open class FatSecretClient {
 
             case .failure(let error):
                 print("Unable to load searched recipes from internet", error.localizedDescription)
-                completion(.failure(.unableToComplete))
+                completion(.failure(.unableToGetRecipes))
             }
         }
     }
@@ -125,7 +125,7 @@ open class FatSecretClient {
 
             case .failure(let error):
                 print("Unable to load searched for recipe id from internet", error.localizedDescription)
-                completion(.failure(.unableToComplete))
+                completion(.failure(.unableToGetRecipes))
             }
         }
     }

--- a/Sources/FatSecretSwift/FatSecretClient.swift
+++ b/Sources/FatSecretSwift/FatSecretClient.swift
@@ -99,7 +99,7 @@ open class FatSecretClient {
      */
     public func searchRecipe(name: String, maxResults: Int = 20, completion: @escaping (Result<FSPRecipes, FBError>) -> Void) {
         let max = (0...50).contains(maxResults) ? maxResults : 20   // maxResults cannot be more than 50. Default value is 20.
-        FatSecretParams.fatSecret = ["format":"json", "method":"recipes.search.v2", "must_have_images":"true", "search_expression":name, "max_results": String(max)] as Dictionary
+        FatSecretParams.fatSecret = ["format":"json", "method":"recipes.search.v3", "must_have_images":"true", "search_expression":name, "max_results": String(max)] as Dictionary
 
         let components = generateSignature()
         fatSecretRecipeSearchRequest(with: components) { result in

--- a/Sources/FatSecretSwift/FatSecretClient.swift
+++ b/Sources/FatSecretSwift/FatSecretClient.swift
@@ -111,7 +111,7 @@ open class FatSecretClient {
     /** Recipe
      - Description: Get a recipe item by id
      */
-    public func getRecipe(id: String, completion: @escaping (_ recipes: FSPSingleRecipe) -> Void) {
+    public func getRecipe(id: String, completion: @escaping (_ recipe: FSPSingleRecipe?) -> Void) {
         print("\nFatSecretClient/searching for Recipe ID....")
         FatSecretParams.fatSecret = ["format":"json", "method":"recipe.get", "recipe_id":id] as Dictionary
 

--- a/Sources/FatSecretSwift/FatSecretClient.swift
+++ b/Sources/FatSecretSwift/FatSecretClient.swift
@@ -97,12 +97,12 @@ open class FatSecretClient {
     /** Recipe Search
      - Description: Search for a recipe by name
      */
-    public func searchRecipe(name: String, maxResults: Int = 20, completion: @escaping (Result<FSPRecipes, FBError>) -> Void) {
+    public func searchRecipe(name: String, maxResults: Int = 20, certPinningDelegate: CertificatePinningURLSessionDelegate? = nil, completion: @escaping (Result<FSPRecipes, FBError>) -> Void) {
         let max = (0...50).contains(maxResults) ? maxResults : 20   // maxResults cannot be more than 50. Default value is 20.
         FatSecretParams.fatSecret = ["format":"json", "method":"recipes.search.v3", "must_have_images":"true", "search_expression":name, "max_results": String(max)] as Dictionary
 
         let components = generateSignature()
-        fatSecretRecipeSearchRequest(with: components) { result in
+        fatSecretRecipeSearchRequest(with: components, certPinningDelegate: certPinningDelegate) { result in
             switch result {
             case .success(let recipes):
 //                print("Successfully found recipes over internet.")
@@ -118,11 +118,11 @@ open class FatSecretClient {
     /** Recipe
      - Description: Get a recipe item by id
      */
-    public func getRecipe(id: String, completion: @escaping (Result<FSPSingleRecipe, FBError>) -> Void) {
+    public func getRecipe(id: String, certPinningDelegate: CertificatePinningURLSessionDelegate? = nil, completion: @escaping (Result<FSPSingleRecipe, FBError>) -> Void) {
         FatSecretParams.fatSecret = ["format":"json", "method":"recipe.get", "recipe_id":id] as Dictionary
 
         let components = generateSignature()
-        fatSecretRecipeIDRequest(with: components) { result in
+        fatSecretRecipeIDRequest(with: components, certPinningDelegate: certPinningDelegate) { result in
             switch result {
             case .success(let recipe):
 //                print("Successfully found recipe id over internet.")

--- a/Sources/FatSecretSwift/FatSecretClient.swift
+++ b/Sources/FatSecretSwift/FatSecretClient.swift
@@ -91,7 +91,7 @@ open class FatSecretClient {
     /** Recipe Search
      - Description: Search for a recipe by name
      */
-    public func searchRecipe(name: String, completion: @escaping (_ recipes: FSPRecipes?) -> Void) {
+    public func searchRecipe(name: String, completion: @escaping (Result<FSPRecipes, FBError>) -> Void) {
         print("\nFatSecretClient/searchRecipe....")
         FatSecretParams.fatSecret = ["format":"json", "method":"recipes.search.v2", "must_have_images":"true", "search_expression":name] as Dictionary
 
@@ -100,10 +100,11 @@ open class FatSecretClient {
             switch result {
             case .success(let recipes):
                 print("Successfully found recipes over internet.")
-                completion(recipes)
+                completion(.success(recipes))
 
             case .failure(let error):
                 print("Unable to load searched recipes from internet", error.localizedDescription)
+                completion(.failure(.unableToComplete))
             }
         }
     }
@@ -111,7 +112,7 @@ open class FatSecretClient {
     /** Recipe
      - Description: Get a recipe item by id
      */
-    public func getRecipe(id: String, completion: @escaping (_ recipe: FSPSingleRecipe?) -> Void) {
+    public func getRecipe(id: String, completion: @escaping (Result<FSPSingleRecipe, FBError>) -> Void) {
         print("\nFatSecretClient/searching for Recipe ID....")
         FatSecretParams.fatSecret = ["format":"json", "method":"recipe.get", "recipe_id":id] as Dictionary
 
@@ -120,10 +121,11 @@ open class FatSecretClient {
             switch result {
             case .success(let recipe):
                 print("Successfully found recipe id over internet.")
-                completion(recipe)
+                completion(.success(recipe))
 
             case .failure(let error):
                 print("Unable to load searched for recipe id from internet", error.localizedDescription)
+                completion(.failure(.unableToComplete))
             }
         }
     }

--- a/Sources/FatSecretSwift/FatSecretClient.swift
+++ b/Sources/FatSecretSwift/FatSecretClient.swift
@@ -93,7 +93,7 @@ open class FatSecretClient {
      */
     public func searchRecipe(name: String, completion: @escaping (_ recipes: FSPRecipes) -> Void) {
         print("\nFatSecretClient/searchRecipe....")
-        FatSecretParams.fatSecret = ["format":"json", "method":"recipes.search.v2", "search_expression":name] as Dictionary
+        FatSecretParams.fatSecret = ["format":"json", "method":"recipes.search.v2", "must_have_images":"true", "search_expression":name] as Dictionary
 
         let components = generateSignature()
         fatSecretRecipeSearchRequest(with: components) { result in

--- a/Sources/FatSecretSwift/FatSecretClient.swift
+++ b/Sources/FatSecretSwift/FatSecretClient.swift
@@ -112,18 +112,18 @@ open class FatSecretClient {
      - Description: Get a recipe item by id
      */
     public func getRecipe(id: String, completion: @escaping (_ recipes: FSPSingleRecipe) -> Void) {
-        print("\nFatSecretClient/searchRecipe....")
+        print("\nFatSecretClient/searching for Recipe ID....")
         FatSecretParams.fatSecret = ["format":"json", "method":"recipe.get", "recipe_id":id] as Dictionary
 
         let components = generateSignature()
         fatSecretRecipeIDRequest(with: components) { result in
             switch result {
             case .success(let recipe):
-                print("Successfully found recipes over internet.")
+                print("Successfully found recipe id over internet.")
                 completion(recipe)
 
             case .failure(let error):
-                print("Unable to load searched recipes from internet", error.localizedDescription)
+                print("Unable to load searched for recipe id from internet", error.localizedDescription)
             }
         }
     }

--- a/Sources/FatSecretSwift/FatSecretClient.swift
+++ b/Sources/FatSecretSwift/FatSecretClient.swift
@@ -98,7 +98,6 @@ open class FatSecretClient {
      - Description: Search for a recipe by name
      */
     public func searchRecipe(name: String, maxResults: Int = 20, completion: @escaping (Result<FSPRecipes, FBError>) -> Void) {
-        print("\nFatSecretClient/searchRecipe....")
         let max = (0...50).contains(maxResults) ? maxResults : 20   // maxResults cannot be more than 50. Default value is 20.
         FatSecretParams.fatSecret = ["format":"json", "method":"recipes.search.v2", "must_have_images":"true", "search_expression":name, "max_results": String(max)] as Dictionary
 

--- a/Sources/FatSecretSwift/FatSecretClient.swift
+++ b/Sources/FatSecretSwift/FatSecretClient.swift
@@ -125,6 +125,78 @@ extension FatSecretClient {
         }
     }
 
+    
+    func fatSecretRecipeSearchRequest(with components: URLComponents, completed: @escaping (Result<FSPRecipes, FBError>) -> Void) {
+        var request = URLRequest(url: URL(string: String(describing: components).replacingOccurrences(of: "+", with: "%2B"))!)
+        request.httpMethod = FatSecretParams.httpType
+
+        let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
+            if let _ = error {
+                completed(.failure(.unableToComplete))
+                return
+            }
+            
+            // error code '200' = OK, i.e., no error.
+            guard let response = response as? HTTPURLResponse, response.statusCode == 200 else {
+                completed(.failure(.invalidResponse))
+                return
+            }
+            
+            guard let data = data else {
+                completed(.failure(.invalidData))
+                return
+            }
+            
+            // After 'guard' error checks, no get/decode the data
+            do {
+                let decoder = JSONDecoder()
+                let recipes = try decoder.decode(FSPRecipeSearch.self, from: data)
+                completed(.success(recipes.recipes)) // escaping value 'recipes.recipes' is of type 'FSPRecipes'
+            } catch {
+                print("Unable to retreive recipes, error: ", error.localizedDescription)
+                completed(.failure(.invalidData))
+            }
+        }
+        task.resume()
+    }
+    
+    
+    func fatSecretRecipeIDRequest(with components: URLComponents, completed: @escaping (Result<FSPSingleRecipe, FBError>) -> Void) {
+        var request = URLRequest(url: URL(string: String(describing: components).replacingOccurrences(of: "+", with: "%2B"))!)
+        request.httpMethod = FatSecretParams.httpType
+
+        let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
+            if let _ = error {
+                completed(.failure(.unableToComplete))
+                return
+            }
+            
+            // error code '200' = OK, i.e., no error.
+            guard let response = response as? HTTPURLResponse, response.statusCode == 200 else {
+                completed(.failure(.invalidResponse))
+                return
+            }
+            
+            guard let data = data else {
+                completed(.failure(.invalidData))
+                return
+            }
+            
+            // After 'guard' error checks, no get/decode the data
+            do {
+                let decoder = JSONDecoder()
+                let recipeID = try decoder.decode(FSPRecipeIDSearch.self, from: data)
+                completed(.success(recipeID.recipe)) // escaping value 'recipeID.recipe' is of type 'FSPSingleRecipe'
+            } catch {
+                print("Unable to retreive recipes, error: ", error.localizedDescription)
+                completed(.failure(.invalidData))
+            }
+        }
+        task.resume()
+    }
+    
+    
+    
     fileprivate func generateSignature() -> URLComponents {
         FatSecretParams.oAuth.updateValue(self.timestamp, forKey: "oauth_timestamp")
         FatSecretParams.oAuth.updateValue(self.nonce, forKey: "oauth_nonce")

--- a/Sources/FatSecretSwift/FatSecretClient.swift
+++ b/Sources/FatSecretSwift/FatSecretClient.swift
@@ -86,6 +86,50 @@ open class FatSecretClient {
             completion(food!)
         }
     }
+    
+    
+    /** Recipe Search
+     - Description: Search for a recipe by name
+     */
+    public func searchRecipe(name: String, completion: @escaping (_ recipes: FSPRecipes) -> Void) {
+        print("\nFatSecretClient/searchRecipe....")
+        FatSecretParams.fatSecret = ["format":"json", "method":"recipes.search.v2", "search_expression":name] as Dictionary
+
+        let components = generateSignature()
+        fatSecretRecipeSearchRequest(with: components) { result in
+            switch result {
+            case .success(let recipes):
+                print("Successfully found recipes over internet.")
+                completion(recipes)
+
+            case .failure(let error):
+                print("Unable to load searched recipes from internet", error.localizedDescription)
+            }
+        }
+    }
+
+    /** Recipe
+     - Description: Get a recipe item by id
+     */
+    public func getRecipe(id: String, completion: @escaping (_ recipes: FSPSingleRecipe) -> Void) {
+        print("\nFatSecretClient/searchRecipe....")
+        FatSecretParams.fatSecret = ["format":"json", "method":"recipe.get", "recipe_id":id] as Dictionary
+
+        let components = generateSignature()
+        fatSecretRecipeIDRequest(with: components) { result in
+            switch result {
+            case .success(let recipe):
+                print("Successfully found recipes over internet.")
+                completion(recipe)
+
+            case .failure(let error):
+                print("Unable to load searched recipes from internet", error.localizedDescription)
+            }
+        }
+    }
+    
+    
+    
 
     public init() {}
 }

--- a/Sources/FatSecretSwift/Models/FSPRecipeID.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeID.swift
@@ -43,7 +43,7 @@ public struct FSPSingleRecipe: Codable, Hashable {
     public let ingredients: Ingredients
     
     public let number_of_servings: String
-    public let preparation_time_min: String
+    public let preparation_time_min: String?
     public let rating: String?
     
     public let recipe_categories: RecipeCategories?

--- a/Sources/FatSecretSwift/Models/FSPRecipeID.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeID.swift
@@ -4,6 +4,29 @@
 //
 //  Created by Fern Botelho on 12/19/22.
 //
+//    MIT License
+//
+//    Copyright (c) 2022 Fernando Botelho.
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy
+//    of this software and associated documentation files (the "Software"), to deal
+//    in the Software without restriction, including without limitation the rights
+//    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//    copies of the Software, and to permit persons to whom the Software is
+//    furnished to do so, subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//    SOFTWARE.
+
+
 
 import Foundation
 

--- a/Sources/FatSecretSwift/Models/FSPRecipeID.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeID.swift
@@ -46,7 +46,7 @@ public struct FSPSingleRecipe: Codable, Hashable {
     public let preparation_time_min: String
     public let rating: String?
     
-    public let recipe_categories: RecipeCategories
+    public let recipe_categories: RecipeCategories?
     public let recipe_description: String
     public let recipe_id: String
     public let recipe_images: RecipeImage

--- a/Sources/FatSecretSwift/Models/FSPRecipeID.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeID.swift
@@ -39,7 +39,7 @@ public struct FSPRecipeIDSearch: Codable, Hashable {
 /** A type that is a recipe property of FSPRecipeIDSearch for decoding FatSecretSwift Recipe ID Search JSON. */
 public struct FSPSingleRecipe: Codable, Hashable {
     public let cooking_time_min: String?
-    public let directions: Directions
+    public let directions: Directions?
     public let ingredients: Ingredients
     
     public let number_of_servings: String
@@ -61,6 +61,28 @@ public struct FSPSingleRecipe: Codable, Hashable {
 /** A type that is a 'directions' property of FSPSingleRecipe, for decoding FatSecretSwift Recipe ID Search JSON. */
 public struct Directions: Codable, Hashable {
     public let direction: [Direction]
+}
+
+
+extension Directions {
+    public enum CodingKeys: String, CodingKey, Hashable {
+        case direction
+    }
+    
+    public init(from decoder: Decoder) throws {
+        do {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            do {
+                let directions = try container.decode([Direction].self, forKey: .direction)
+                self.init(direction: directions)
+            } catch {
+                let direction = try container.decode(Direction.self, forKey: .direction)
+                self.init(direction: [direction])
+            }
+        } catch {
+            self.init(direction: [Direction(direction_description: "n/a", direction_number: "0")])
+        }
+    }
 }
 
 

--- a/Sources/FatSecretSwift/Models/FSPRecipeID.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeID.swift
@@ -49,7 +49,7 @@ public struct FSPSingleRecipe: Codable, Hashable {
     public let recipe_categories: RecipeCategories?
     public let recipe_description: String
     public let recipe_id: String
-    public let recipe_images: RecipeImage
+    public let recipe_images: RecipeImage?
     public let recipe_name: String
     public let recipe_types: RecipeTypes?
     public let recipe_url: URL?
@@ -176,7 +176,13 @@ extension RecipeImage {
 
 /** A type that is a 'recipe_types' property of FSPSingleRecipe, for decoding FatSecretSwift Recipe ID JSON. */
 public struct RecipeTypes: Codable, Hashable {
-    public let recipe_type: [String]
+    public let recipe_type: RecipeType
+    public var associatedValue: [String]
+}
+
+public enum RecipeType: Codable, Hashable {
+    case string(String)
+    case stringArray([String])
 }
 
 
@@ -188,16 +194,15 @@ extension RecipeTypes {
     public init(from decoder: Decoder) throws {
         do {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            do {
-                let recipeType  = try container.decode([String].self, forKey: .recipe_type)
-                self.init(recipe_type: recipeType)
-            } catch {
-                let recipeStringType = (try? container.decode(String.self, forKey: .recipe_type)) ?? ""
-                let recipeType = [recipeStringType]
-                self.init(recipe_type: recipeType)
-            }
+                let recipeType  = try container.decode(RecipeType.self, forKey: .recipe_type)
+                switch recipeType {
+                case .string(let recipeString):
+                    self.init(recipe_type: recipeType, associatedValue: [recipeString])
+                case .stringArray(let recipeStringArray):
+                    self.init(recipe_type: recipeType, associatedValue: recipeStringArray)
+                }
         } catch {
-            self.init(recipe_type: ["n/a"])
+            self.init(recipe_type: RecipeType.stringArray(["n/a"]), associatedValue: ["n/a"])
         }
     }
 }

--- a/Sources/FatSecretSwift/Models/FSPRecipeID.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeID.swift
@@ -51,7 +51,7 @@ public struct FSPSingleRecipe: Codable, Hashable {
     public let recipe_id: String
     public let recipe_images: RecipeImage
     public let recipe_name: String
-    public let recipe_types: RecipeTypes
+    public let recipe_types: RecipeTypes?
     public let recipe_url: URL?
     
     public let serving_sizes: FSPRecipeServing

--- a/Sources/FatSecretSwift/Models/FSPRecipeID.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeID.swift
@@ -225,7 +225,7 @@ public struct FSPRecipeServingInfo: Codable, Hashable {
     public let sodium: Double?
     public let sugar: Double?
     public let trans_fat: Double?
-    public let vitamin_a: Double?
+//    public let vitamin_a: Double?
     public let vitamin_c: Double?
 }
 
@@ -250,7 +250,7 @@ extension FSPRecipeServingInfo {
         case sodium
         case sugar
         case trans_fat
-        case vitamin_a
+//        case vitamin_a
         case vitamin_c
     }
     
@@ -276,14 +276,14 @@ extension FSPRecipeServingInfo {
             let sodium              = (try? container.decode(String.self, forKey: .sodium)) ?? ""
             let sugar               = (try? container.decode(String.self, forKey: .sugar)) ?? ""
             let trans_fat           = (try? container.decode(String.self, forKey: .trans_fat)) ?? ""
-            let vitamin_a           = (try? container.decode(String.self, forKey: .vitamin_a)) ?? ""
+//            let vitamin_a           = (try? container.decode(String.self, forKey: .vitamin_a)) ?? ""
             let vitamin_c           = (try? container.decode(String.self, forKey: .vitamin_c)) ?? ""
             
             // Convert decoded Strings as Doubles
-            self.init(calcium: Double(calcium), calories: Double(calories), carbohydrate: Double(carbohydrate), cholesterol: Double(cholesterol), fat: Double(fat), fiber: Double(fiber), iron: Double(iron), monounsaturated_fat: Double(monounsaturated_fat), polyunsaturated_fat: Double(polyunsaturated_fat), potassium: Double(potassium), protein: Double(protein), saturated_fat: Double(saturated_fat), serving_size: Double(serving_size), sodium: Double(sodium), sugar: Double(sugar), trans_fat: Double(trans_fat), vitamin_a: Double(vitamin_a), vitamin_c: Double(vitamin_c))
+            self.init(calcium: Double(calcium), calories: Double(calories), carbohydrate: Double(carbohydrate), cholesterol: Double(cholesterol), fat: Double(fat), fiber: Double(fiber), iron: Double(iron), monounsaturated_fat: Double(monounsaturated_fat), polyunsaturated_fat: Double(polyunsaturated_fat), potassium: Double(potassium), protein: Double(protein), saturated_fat: Double(saturated_fat), serving_size: Double(serving_size), sodium: Double(sodium), sugar: Double(sugar), trans_fat: Double(trans_fat), vitamin_c: Double(vitamin_c))
         } catch {
             // If unable to decode 'container' then function returns 0.0 for all properties
-            self.init(calcium: 0.0, calories: 0.0, carbohydrate: 0.0, cholesterol: 0.0, fat: 0.0, fiber: 0.0, iron: 0.0, monounsaturated_fat: 0.0, polyunsaturated_fat: 0.0, potassium: 0.0, protein: 0.0, saturated_fat: 0.0, serving_size: 0.0, sodium: 0.0, sugar: 0.0, trans_fat: 0.0, vitamin_a: 0.0, vitamin_c: 0.0)
+            self.init(calcium: 0.0, calories: 0.0, carbohydrate: 0.0, cholesterol: 0.0, fat: 0.0, fiber: 0.0, iron: 0.0, monounsaturated_fat: 0.0, polyunsaturated_fat: 0.0, potassium: 0.0, protein: 0.0, saturated_fat: 0.0, serving_size: 0.0, sodium: 0.0, sugar: 0.0, trans_fat: 0.0, vitamin_c: 0.0)
         }
     }
     

--- a/Sources/FatSecretSwift/Models/FSPRecipeID.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeID.swift
@@ -114,6 +114,30 @@ public struct RecipeTypes: Codable, Hashable {
 }
 
 
+extension RecipeTypes {
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case recipe_type
+    }
+    
+    public init(from decoder: Decoder) throws {
+        do {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            do {
+                let recipeType  = try container.decode([String].self, forKey: .recipe_type)
+                self.init(recipe_type: recipeType)
+            } catch {
+                let recipeStringType = (try? container.decode(String.self, forKey: .recipe_type)) ?? ""
+                let recipeType = [recipeStringType]
+                self.init(recipe_type: recipeType)
+            }
+        } catch {
+            self.init(recipe_type: ["n/a"])
+        }
+    }
+}
+
+
+
 /** A type that is a 'serving_sizes' property of FSPSingleRecipe, for decoding FatSecretSwift Recipe ID JSON. */
 public struct FSPRecipeServing: Codable, Hashable {
     public let serving: FSPRecipeServingInfo
@@ -201,4 +225,5 @@ extension FSPRecipeServingInfo {
             self.init(calcium: 0.0, calories: 0.0, carbohydrate: 0.0, cholesterol: 0.0, fat: 0.0, fiber: 0.0, iron: 0.0, monounsaturated_fat: 0.0, polyunsaturated_fat: 0.0, potassium: 0.0, protein: 0.0, saturated_fat: 0.0, serving_size: 0.0, sodium: 0.0, sugar: 0.0, trans_fat: 0.0, vitamin_a: 0.0, vitamin_c: 0.0)
         }
     }
+    
 }

--- a/Sources/FatSecretSwift/Models/FSPRecipeID.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeID.swift
@@ -4,10 +4,7 @@
 //
 //  Created by Fern Botelho on 12/19/22.
 //
-<<<<<<< HEAD
 //
-=======
->>>>>>> AddRecipeSearch_wFilters
 //    MIT License
 //
 //    Copyright (c) 2022 Fernando Botelho.
@@ -29,11 +26,7 @@
 //    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //    SOFTWARE.
-<<<<<<< HEAD
-=======
 
-
->>>>>>> AddRecipeSearch_wFilters
 
 import Foundation
 

--- a/Sources/FatSecretSwift/Models/FSPRecipeID.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeID.swift
@@ -1,0 +1,181 @@
+//
+//  FSPRecipeID.swift  (FSP = FatSecretPlatform)
+//
+//
+//  Created by Fern Botelho on 12/19/22.
+//
+
+import Foundation
+
+/** root struct for decoding FatSecretSwift Recipe ID Search JSON data. */
+public struct FSPRecipeIDSearch: Codable, Hashable {
+    public let recipe: FSPSingleRecipe
+}
+
+
+/** A type that is a recipe property of FSPRecipeIDSearch for decoding FatSecretSwift Recipe ID Search JSON. */
+public struct FSPSingleRecipe: Codable, Hashable {
+    public let cooking_time_min: String?
+    public let directions: Directions
+    public let ingredients: Ingredients
+    
+    public let number_of_servings: String
+    public let preparation_time_min: String
+    public let rating: String
+    
+    public let recipe_categories: RecipeCategories
+    public let recipe_description: String
+    public let recipe_id: String
+    public let recipe_images: RecipeImage
+    public let recipe_name: String
+    public let recipe_types: RecipeTypes
+    public let recipe_url: URL?
+    
+    public let serving_sizes: FSPRecipeServing
+}
+
+
+/** A type that is a 'directions' property of FSPSingleRecipe, for decoding FatSecretSwift Recipe ID Search JSON. */
+public struct Directions: Codable, Hashable {
+    public let direction: [Direction]
+}
+
+
+/** A Directions.direction array item type for decoding FatSecretSwift Recipe ID Search JSON. */
+public struct Direction: Codable, Hashable {
+    public let direction_description: String
+    public let direction_number: String
+}
+
+
+/** A type that is an 'ingredients' property of FSPSingleRecipe, for decoding FatSecretSwift Recipe ID Search JSON. */
+public struct Ingredients: Codable, Hashable {
+    public let ingredient: [Ingredient]
+}
+
+
+/** An Ingredients.ingredient array item type for decoding FatSecretSwift Recipe ID Search JSON. */
+public struct Ingredient: Codable, Hashable {
+    public let food_id: String
+    public let food_name: String
+    public let ingredient_description: String
+    public let ingredient_url: URL
+    public let measurement_description: String
+    public let number_of_units: String
+    public let serving_id: String
+}
+
+
+/** A type that is a 'recipe_categories' property of FSPSingleRecipe, for decoding FatSecretSwift Recipe ID Search JSON. */
+public struct RecipeCategories: Codable, Hashable {
+    public let recipe_category: [RecipeCategory]
+}
+
+
+/** A RecipeCategories.recipe_category array item type for decoding FatSecretSwift Recipe ID JSON. */
+public struct RecipeCategory: Codable, Hashable {
+    public let recipe_category_name: String
+    public let recipe_category_url: URL?
+}
+
+
+/** A type that is a 'recipe_images' property of FSPSingleRecipe, for decoding FatSecretSwift Recipe ID JSON. */
+public struct RecipeImage: Codable, Hashable {
+    public let recipe_image: URL?
+}
+
+
+/** A type that is a 'recipe_types' property of FSPSingleRecipe, for decoding FatSecretSwift Recipe ID JSON. */
+public struct RecipeTypes: Codable, Hashable {
+    public let recipe_type: [String]
+}
+
+
+/** A type that is a 'serving_sizes' property of FSPSingleRecipe, for decoding FatSecretSwift Recipe ID JSON. */
+public struct FSPRecipeServing: Codable, Hashable {
+    public let serving: FSPRecipeServingInfo
+}
+
+
+/** A type that is a 'serving' property of FSPSingleRecipe, for decoding FatSecretSwift Recipe ID JSON. Note: Using custum decoder in extension to convert decoded JSON String values in optional Double values. */
+public struct FSPRecipeServingInfo: Codable, Hashable {
+    public let calcium: Double?
+    public let calories: Double?
+    public let carbohydrate: Double?
+    public let cholesterol: Double?
+    public let fat: Double?
+    public let fiber: Double?
+    public let iron: Double?
+    public let monounsaturated_fat: Double?
+    public let polyunsaturated_fat: Double?
+    public let potassium: Double?
+    public let protein: Double?
+    public let saturated_fat: Double?
+    
+    public let serving_size: Double?
+    
+    public let sodium: Double?
+    public let sugar: Double?
+    public let trans_fat: Double?
+    public let vitamin_a: Double?
+    public let vitamin_c: Double?
+}
+
+
+extension FSPRecipeServingInfo {
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case calcium
+        case calories
+        case carbohydrate
+        case cholesterol
+        case fat
+        case fiber
+        case iron
+        case monounsaturated_fat
+        case polyunsaturated_fat
+        case potassium
+        case protein
+        case saturated_fat
+        
+        case serving_size
+        
+        case sodium
+        case sugar
+        case trans_fat
+        case vitamin_a
+        case vitamin_c
+    }
+    
+    
+    public init(from decoder: Decoder) throws {
+        do {
+            let container           = try decoder.container(keyedBy: CodingKeys.self)
+            let calcium             = (try? container.decode(String.self, forKey: .calcium)) ?? ""
+            let calories            = (try? container.decode(String.self, forKey: .calories)) ?? ""
+            let carbohydrate        = (try? container.decode(String.self, forKey: .carbohydrate)) ?? ""
+            let cholesterol         = (try? container.decode(String.self, forKey: .cholesterol)) ?? ""
+            let fat                 = (try? container.decode(String.self, forKey: .fat)) ?? ""
+            let fiber               = (try? container.decode(String.self, forKey: .fiber)) ?? ""
+            let iron                = (try? container.decode(String.self, forKey: .iron)) ?? ""
+            let monounsaturated_fat = (try? container.decode(String.self, forKey: .monounsaturated_fat)) ?? ""
+            let polyunsaturated_fat = (try? container.decode(String.self, forKey: .polyunsaturated_fat)) ?? ""
+            let potassium           = (try? container.decode(String.self, forKey: .potassium)) ?? ""
+            let protein             = (try? container.decode(String.self, forKey: .protein)) ?? ""
+            let saturated_fat       = (try? container.decode(String.self, forKey: .saturated_fat)) ?? ""
+        
+            let serving_size        = (try? container.decode(String.self, forKey: .serving_size)) ?? ""
+        
+            let sodium              = (try? container.decode(String.self, forKey: .sodium)) ?? ""
+            let sugar               = (try? container.decode(String.self, forKey: .sugar)) ?? ""
+            let trans_fat           = (try? container.decode(String.self, forKey: .trans_fat)) ?? ""
+            let vitamin_a           = (try? container.decode(String.self, forKey: .vitamin_a)) ?? ""
+            let vitamin_c           = (try? container.decode(String.self, forKey: .vitamin_c)) ?? ""
+            
+            // Convert decoded Strings as Doubles
+            self.init(calcium: Double(calcium), calories: Double(calories), carbohydrate: Double(carbohydrate), cholesterol: Double(cholesterol), fat: Double(fat), fiber: Double(fiber), iron: Double(iron), monounsaturated_fat: Double(monounsaturated_fat), polyunsaturated_fat: Double(polyunsaturated_fat), potassium: Double(potassium), protein: Double(protein), saturated_fat: Double(saturated_fat), serving_size: Double(serving_size), sodium: Double(sodium), sugar: Double(sugar), trans_fat: Double(trans_fat), vitamin_a: Double(vitamin_a), vitamin_c: Double(vitamin_c))
+        } catch {
+            // If unable to decode 'container' then function returns 0.0 for all properties
+            self.init(calcium: 0.0, calories: 0.0, carbohydrate: 0.0, cholesterol: 0.0, fat: 0.0, fiber: 0.0, iron: 0.0, monounsaturated_fat: 0.0, polyunsaturated_fat: 0.0, potassium: 0.0, protein: 0.0, saturated_fat: 0.0, serving_size: 0.0, sodium: 0.0, sugar: 0.0, trans_fat: 0.0, vitamin_a: 0.0, vitamin_c: 0.0)
+        }
+    }
+}

--- a/Sources/FatSecretSwift/Models/FSPRecipeID.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeID.swift
@@ -4,6 +4,28 @@
 //
 //  Created by Fern Botelho on 12/19/22.
 //
+//
+//    MIT License
+//
+//    Copyright (c) 2022 Fernando Botelho.
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy
+//    of this software and associated documentation files (the "Software"), to deal
+//    in the Software without restriction, including without limitation the rights
+//    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//    copies of the Software, and to permit persons to whom the Software is
+//    furnished to do so, subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//    SOFTWARE.
 
 import Foundation
 

--- a/Sources/FatSecretSwift/Models/FSPRecipeID.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeID.swift
@@ -194,13 +194,13 @@ extension RecipeTypes {
     public init(from decoder: Decoder) throws {
         do {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-                let recipeType  = try container.decode(RecipeType.self, forKey: .recipe_type)
-                switch recipeType {
-                case .string(let recipeString):
-                    self.init(recipe_type: recipeType, associatedValue: [recipeString])
-                case .stringArray(let recipeStringArray):
-                    self.init(recipe_type: recipeType, associatedValue: recipeStringArray)
-                }
+            let recipeType  = try container.decode(RecipeType.self, forKey: .recipe_type)
+            switch recipeType {
+            case .string(let recipeString):
+                self.init(recipe_type: recipeType, associatedValue: [recipeString])
+            case .stringArray(let recipeStringArray):
+                self.init(recipe_type: recipeType, associatedValue: recipeStringArray)
+            }
         } catch {
             self.init(recipe_type: RecipeType.stringArray(["n/a"]), associatedValue: ["n/a"])
         }

--- a/Sources/FatSecretSwift/Models/FSPRecipeID.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeID.swift
@@ -44,7 +44,7 @@ public struct FSPSingleRecipe: Codable, Hashable {
     
     public let number_of_servings: String
     public let preparation_time_min: String
-    public let rating: String
+    public let rating: String?
     
     public let recipe_categories: RecipeCategories
     public let recipe_description: String

--- a/Sources/FatSecretSwift/Models/FSPRecipeID.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeID.swift
@@ -176,13 +176,7 @@ extension RecipeImage {
 
 /** A type that is a 'recipe_types' property of FSPSingleRecipe, for decoding FatSecretSwift Recipe ID JSON. */
 public struct RecipeTypes: Codable, Hashable {
-    public let recipe_type: RecipeType
-    public var associatedValue: [String]
-}
-
-public enum RecipeType: Codable, Hashable {
-    case string(String)
-    case stringArray([String])
+    public let recipe_type: [String]?
 }
 
 
@@ -192,17 +186,13 @@ extension RecipeTypes {
     }
     
     public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
         do {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            let recipeType  = try container.decode(RecipeType.self, forKey: .recipe_type)
-            switch recipeType {
-            case .string(let recipeString):
-                self.init(recipe_type: recipeType, associatedValue: [recipeString])
-            case .stringArray(let recipeStringArray):
-                self.init(recipe_type: recipeType, associatedValue: recipeStringArray)
-            }
+            let recipeTypes  = try container.decode([String].self, forKey: .recipe_type)
+            self.init(recipe_type: recipeTypes)
         } catch {
-            self.init(recipe_type: RecipeType.stringArray(["n/a"]), associatedValue: ["n/a"])
+            let recipeType  = try container.decode(String.self, forKey: .recipe_type)
+            self.init(recipe_type: [recipeType])
         }
     }
 }

--- a/Sources/FatSecretSwift/Models/FSPRecipeID.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeID.swift
@@ -95,6 +95,28 @@ public struct RecipeCategories: Codable, Hashable {
 }
 
 
+extension RecipeCategories {
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case recipe_category
+    }
+    
+    public init(from decoder: Decoder) throws {
+        do {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            do {
+                let recipeCategories = try container.decode([RecipeCategory].self, forKey: .recipe_category)
+                self.init(recipe_category: recipeCategories)
+            } catch {
+                let recipeCategory = try container.decode(RecipeCategory.self, forKey: .recipe_category)
+                self.init(recipe_category: [recipeCategory])
+            }
+        } catch {
+            self.init(recipe_category: [RecipeCategory(recipe_category_name: "no category name", recipe_category_url: nil)])
+        }
+    }
+}
+
+
 /** A RecipeCategories.recipe_category array item type for decoding FatSecretSwift Recipe ID JSON. */
 public struct RecipeCategory: Codable, Hashable {
     public let recipe_category_name: String
@@ -104,7 +126,29 @@ public struct RecipeCategory: Codable, Hashable {
 
 /** A type that is a 'recipe_images' property of FSPSingleRecipe, for decoding FatSecretSwift Recipe ID JSON. */
 public struct RecipeImage: Codable, Hashable {
-    public let recipe_image: URL?
+    public let recipe_image: [URL]?
+}
+
+
+extension RecipeImage {
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case recipe_image
+    }
+    
+    public init(from decoder: Decoder) throws {
+        do {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            do {
+                let recipeImages = try container.decode([URL].self, forKey: .recipe_image)
+                self.init(recipe_image: recipeImages)
+            } catch {
+                let recipeImage = try container.decode(URL.self, forKey: .recipe_image)
+                self.init(recipe_image: [recipeImage])
+            }
+        } catch {
+            self.init(recipe_image: nil)
+        }
+    }
 }
 
 

--- a/Sources/FatSecretSwift/Models/FSPRecipeSearch.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeSearch.swift
@@ -94,7 +94,7 @@ extension FSPRecipeType {
 
 extension FSPNutrition {
     public enum CodingKeys: String, CodingKey, CaseIterable {
-        case calories,carbohydrate, fat, protein
+        case calories, carbohydrate, fat, protein
     }
     
     public init(from decoder: Decoder) throws {

--- a/Sources/FatSecretSwift/Models/FSPRecipeSearch.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeSearch.swift
@@ -4,10 +4,7 @@
 //
 //  Created by Fern Botelho on 12/19/22.
 //
-<<<<<<< HEAD
 //
-=======
->>>>>>> AddRecipeSearch_wFilters
 //    MIT License
 //
 //    Copyright (c) 2022 Fernando Botelho.

--- a/Sources/FatSecretSwift/Models/FSPRecipeSearch.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeSearch.swift
@@ -68,17 +68,36 @@ public struct FSPNutrition: Codable, Hashable {
 
 /** A type that is a 'recipe_types' property of FSPRecipe, for decoding FatSecretSwift Recipe Search JSON. 'recipe_type' in FSPRecipeType uses a custom decoder init(from decoder:) in extension to FSPRecipeType, as 'recipe_type' may be a String or Array< String >. */
 public struct FSPRecipeType: Codable, Hashable {
-    public let recipe_type: [String]
+    public let recipe_type: FatRecipeType
+    public var associatedValue: [String]
 }
 
 
+public enum FatRecipeType: Codable, Hashable {
+    case string(String)
+    case stringArray([String])
+}
+
+
+
 extension FSPRecipeType {
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case recipe_type
+    }
+    
+    
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
         do {
-            recipe_type = try [String(container.decode(String.self, forKey: .recipe_type))]
+            let container  = try decoder.container(keyedBy: CodingKeys.self)
+            let recipeType = try container.decode(FatRecipeType.self, forKey: .recipe_type)
+            switch recipeType {
+            case .string(let recipeString):
+                self.init(recipe_type: recipeType, associatedValue: [recipeString])
+            case .stringArray(let recipeStringArray):
+                self.init(recipe_type: recipeType, associatedValue: recipeStringArray)
+            }
         } catch {
-            recipe_type = try container.decode([String].self, forKey: .recipe_type)
+            self.init(recipe_type: FatRecipeType.stringArray(["n/a"]), associatedValue: ["n/a"])
         }
     }
 }

--- a/Sources/FatSecretSwift/Models/FSPRecipeSearch.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeSearch.swift
@@ -68,14 +68,7 @@ public struct FSPNutrition: Codable, Hashable {
 
 /** A type that is a 'recipe_types' property of FSPRecipe, for decoding FatSecretSwift Recipe Search JSON. 'recipe_type' in FSPRecipeType uses a custom decoder init(from decoder:) in extension to FSPRecipeType, as 'recipe_type' may be a String or Array< String >. */
 public struct FSPRecipeType: Codable, Hashable {
-    public let recipe_type: FatRecipeType
-    public var associatedValue: [String]
-}
-
-
-public enum FatRecipeType: Codable, Hashable {
-    case string(String)
-    case stringArray([String])
+    public let recipe_type: [String]?
 }
 
 
@@ -85,21 +78,17 @@ extension FSPRecipeType {
         case recipe_type
     }
     
-    
     public init(from decoder: Decoder) throws {
+        let container  = try decoder.container(keyedBy: CodingKeys.self)
         do {
-            let container  = try decoder.container(keyedBy: CodingKeys.self)
-            let recipeType = try container.decode(FatRecipeType.self, forKey: .recipe_type)
-            switch recipeType {
-            case .string(let recipeString):
-                self.init(recipe_type: recipeType, associatedValue: [recipeString])
-            case .stringArray(let recipeStringArray):
-                self.init(recipe_type: recipeType, associatedValue: recipeStringArray)
-            }
+            let recipeTypes = try container.decode([String].self, forKey: .recipe_type)
+            self.init(recipe_type: recipeTypes)
         } catch {
-            self.init(recipe_type: FatRecipeType.stringArray(["n/a"]), associatedValue: ["n/a"])
+            let recipeType = try container.decode(String.self, forKey: .recipe_type)
+            self.init(recipe_type: [recipeType])
         }
     }
+
 }
 
 

--- a/Sources/FatSecretSwift/Models/FSPRecipeSearch.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeSearch.swift
@@ -4,6 +4,27 @@
 //
 //  Created by Fern Botelho on 12/19/22.
 //
+//    MIT License
+//
+//    Copyright (c) 2022 Fernando Botelho.
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy
+//    of this software and associated documentation files (the "Software"), to deal
+//    in the Software without restriction, including without limitation the rights
+//    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//    copies of the Software, and to permit persons to whom the Software is
+//    furnished to do so, subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//    SOFTWARE.
 
 import Foundation
 

--- a/Sources/FatSecretSwift/Models/FSPRecipeSearch.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeSearch.swift
@@ -1,0 +1,85 @@
+//
+//  FSPRecipeSearch.swift   (FSP = FatSecretPlatform)
+//
+//
+//  Created by Fern Botelho on 12/19/22.
+//
+
+import Foundation
+
+/** A root struct for decoding FatSecretSwift recipe search JSON data. */
+public struct FSPRecipeSearch: Codable, Hashable {
+    public let recipes: FSPRecipes
+}
+
+/** A child struct of FSPRecipeSearch for decoding FatSecretSwift Recipe Search JSON. */
+public struct FSPRecipes: Codable, Hashable {
+    public let recipe: [FSPRecipe]
+}
+
+
+/** An FSPRecipes.recipe array item type for decoding FatSecretSwift Recipe Search JSON. */
+public struct FSPRecipe: Codable, Hashable {
+    public let recipe_description: String?
+    public let recipe_id: String?
+    public let recipe_image: URL?
+    public let recipe_ingredients: FSPIngredient?
+    public let recipe_name: String?
+    public let recipe_nutrition: FSPNutrition?
+    public let recipe_types: FSPRecipeType?
+}
+
+
+/** A type that is a 'recipe_ingredients' property of FSPRecipe, for decoding FatSecretSwift Recipe Search JSON. */
+public struct FSPIngredient: Codable, Hashable {
+    public let ingredient: [String]?
+}
+
+/** A type that is a 'recipe_nutritrion' property of FSPRecipe, for decoding FatSecretSwift Recipe Search JSON. Note: Using custum decoder in extension to convert decoded JSON String values in optional Double values. */
+public struct FSPNutrition: Codable, Hashable {
+    public let calories: Double?
+    public let carbohydrate: Double?
+    public let fat: Double?
+    public let protein: Double?
+}
+
+
+/** A type that is a 'recipe_types' property of FSPRecipe, for decoding FatSecretSwift Recipe Search JSON. 'recipe_type' in FSPRecipeType uses a custom decoder init(from decoder:) in extension to FSPRecipeType, as 'recipe_type' may be a String or Array< String >. */
+public struct FSPRecipeType: Codable, Hashable {
+    public let recipe_type: [String]
+}
+
+
+extension FSPRecipeType {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        do {
+            recipe_type = try [String(container.decode(String.self, forKey: .recipe_type))]
+        } catch {
+            recipe_type = try container.decode([String].self, forKey: .recipe_type)
+        }
+    }
+}
+
+
+extension FSPNutrition {
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case calories,carbohydrate, fat, protein
+    }
+    
+    public init(from decoder: Decoder) throws {
+        do {
+            let container       = try decoder.container(keyedBy: CodingKeys.self)
+            let calories        = (try? container.decode(String.self, forKey: .calories)) ?? ""
+            let carbohydrate    = (try? container.decode(String.self, forKey: .carbohydrate)) ?? ""
+            let fat             = (try? container.decode(String.self, forKey: .fat)) ?? ""
+            let protein         = (try? container.decode(String.self, forKey: .protein)) ?? ""
+            // Convert decoded Strings as Doubles
+            self.init(calories: Double(calories), carbohydrate: Double(carbohydrate), fat: Double(fat), protein: Double(protein))
+        } catch {
+            self.init(calories: 0.0, carbohydrate: 0.0, fat: 0.0, protein: 0.0)
+        }
+    }
+    
+    
+}

--- a/Sources/FatSecretSwift/Models/FSPRecipeSearch.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeSearch.swift
@@ -4,6 +4,28 @@
 //
 //  Created by Fern Botelho on 12/19/22.
 //
+//
+//    MIT License
+//
+//    Copyright (c) 2022 Fernando Botelho.
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy
+//    of this software and associated documentation files (the "Software"), to deal
+//    in the Software without restriction, including without limitation the rights
+//    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//    copies of the Software, and to permit persons to whom the Software is
+//    furnished to do so, subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//    SOFTWARE.
 
 import Foundation
 

--- a/Sources/FatSecretSwift/Models/FSPRecipeSearch.swift
+++ b/Sources/FatSecretSwift/Models/FSPRecipeSearch.swift
@@ -57,6 +57,24 @@ public struct FSPIngredient: Codable, Hashable {
     public let ingredient: [String]?
 }
 
+
+extension FSPIngredient {
+    public enum CodingKeys: String, CodingKey, CaseIterable {
+        case ingredient
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        do {
+            let ingredients = try container.decode([String].self, forKey: .ingredient)
+            self.init(ingredient: ingredients)
+        } catch {
+            let ingredient = try container.decode(String.self, forKey: .ingredient)
+            self.init(ingredient: [ingredient])
+        }
+    }
+}
+
 /** A type that is a 'recipe_nutritrion' property of FSPRecipe, for decoding FatSecretSwift Recipe Search JSON. Note: Using custum decoder in extension to convert decoded JSON String values in optional Double values. */
 public struct FSPNutrition: Codable, Hashable {
     public let calories: Double?

--- a/Sources/FatSecretSwift/Models/FatSecretError.swift
+++ b/Sources/FatSecretSwift/Models/FatSecretError.swift
@@ -5,7 +5,8 @@ public struct FSError: Codable {
 
 
 public enum FBError: String, Error {
-    case unableToComplete       = "Unable to comple request. Please check internet connection."
+    case unableToComplete       = "Unable to complete request. Please check internet connection."
+    case unableToGetRecipes     = "Unable to get Recipes. Please check internet connection."
     case invalidResponse        = "Invalid response from server. Try again."
     case invalidData            = "The data received from server was invalid. Try again."
 }

--- a/Sources/FatSecretSwift/Models/FatSecretError.swift
+++ b/Sources/FatSecretSwift/Models/FatSecretError.swift
@@ -6,7 +6,7 @@ public struct FSError: Codable {
 
 public enum FBError: String, Error {
     case unableToComplete       = "Unable to complete request. Please check internet connection."
-    case unableToGetRecipes     = "Unable to get Recipes. Please check internet connection."
+    case unableToGetRecipes     = "No matches found. Recipe unavailable from on-line connection."
     case invalidResponse        = "Invalid response from server. Try again."
     case invalidData            = "The data received from server was invalid. Try again."
 }

--- a/Sources/FatSecretSwift/Models/FatSecretError.swift
+++ b/Sources/FatSecretSwift/Models/FatSecretError.swift
@@ -6,7 +6,7 @@ public struct FSError: Codable {
 
 public enum FBError: String, Error {
     case unableToComplete       = "Unable to complete request. Please check internet connection."
-    case unableToGetRecipes     = "No matches found. Recipe unavailable from on-line connection."
+    case unableToGetRecipes     = "No recipes found on-line (not available or no internet connection)."
     case invalidResponse        = "Invalid response from server. Try again."
     case invalidData            = "The data received from server was invalid. Try again."
 }

--- a/Sources/FatSecretSwift/Models/FatSecretError.swift
+++ b/Sources/FatSecretSwift/Models/FatSecretError.swift
@@ -2,3 +2,10 @@ public struct FSError: Codable {
     let code: Int
     let message: String?
 }
+
+
+public enum FBError: String, Error {
+    case unableToComplete       = "Unable to comple request. Please check internet connection."
+    case invalidResponse        = "Invalid response from server. Try again."
+    case invalidData            = "The data received from server was invalid. Try again."
+}

--- a/Sources/FatSecretSwift/Models/Food.swift
+++ b/Sources/FatSecretSwift/Models/Food.swift
@@ -1,9 +1,9 @@
 public struct Food: Decodable {
     public enum CodingKeys: String, CodingKey, CaseIterable {
-        case id = "food_id"
-        case name = "food_name"
-        case type = "food_type"
-        case url = "food_url"
+        case id     = "food_id"
+        case name   = "food_name"
+        case type   = "food_type"
+        case url    = "food_url"
         case servings
     }
 

--- a/Sources/FatSecretSwift/Models/SearchedFood.swift
+++ b/Sources/FatSecretSwift/Models/SearchedFood.swift
@@ -1,11 +1,11 @@
 public struct SearchedFood: Decodable {
    public enum CodingKeys: String, CodingKey {
-        case id = "food_id"
-        case name = "food_name"
-        case description = "food_description"
-        case brand = "brand_name"
-        case type = "food_type"
-        case url = "food_url"
+        case id             = "food_id"
+        case name           = "food_name"
+        case description    = "food_description"
+        case brand          = "brand_name"
+        case type           = "food_type"
+        case url            = "food_url"
     }
 
     public let id: String

--- a/Sources/FatSecretSwift/Models/Serving.swift
+++ b/Sources/FatSecretSwift/Models/Serving.swift
@@ -5,7 +5,7 @@ public struct Serving: Decodable {
         case polyunsaturatedFat = "polyunsaturated_fat"
         case saturatedFat       = "saturated_fat"
         case transFat           = "trans_fat"
-        case vitaminA           = "vitamin_a"
+//        case vitaminA           = "vitamin_a"
         case vitaminC           = "vitamin_c"
     }
 
@@ -24,7 +24,7 @@ public struct Serving: Decodable {
     public let sodium: String?
     public let sugar: String?
     public let transFat: String?
-    public let vitaminA: String?
+//    public let vitaminA: String?
     public let vitaminC: String?
 
     public init(calcium: String?, calories: String?, carbohydrate: String?, cholesterol: String?, fat: String?,
@@ -46,7 +46,7 @@ public struct Serving: Decodable {
         self.sodium = sodium
         self.sugar = sugar
         self.transFat = transFat
-        self.vitaminA = vitaminA
+//        self.vitaminA = vitaminA
         self.vitaminC = vitaminC
     }
 }

--- a/Sources/FatSecretSwift/Models/Serving.swift
+++ b/Sources/FatSecretSwift/Models/Serving.swift
@@ -3,10 +3,10 @@ public struct Serving: Decodable {
         case calcium, calories, carbohydrate, cholesterol, fat, fiber, iron, potassium, protein, sodium, sugar
         case monounsaturatedFat = "monounsaturated_fat"
         case polyunsaturatedFat = "polyunsaturated_fat"
-        case saturatedFat = "saturated_fat"
-        case transFat = "trans_fat"
-        case vitaminA = "vitamin_a"
-        case vitaminC = "vitamin_c"
+        case saturatedFat       = "saturated_fat"
+        case transFat           = "trans_fat"
+        case vitaminA           = "vitamin_a"
+        case vitaminC           = "vitamin_c"
     }
 
     public let calcium: String?


### PR DESCRIPTION
Hi Nicholas, 

I've added the ability to do a recipe search by recipe_id or search_expression in FatSecretSwift when using the FatSecretPlatform (FSP) API. Added swift model files FSPRecipeSearch.swift and FSPRecipeID.swift, and made updates to FatSecretError and FatSecretClient. Feel free to add to your base repository and welcome any suggestions. cheers.  

Fern. (aka Frank.)